### PR TITLE
change github pages to netlify for hosting

### DIFF
--- a/trainingbreakdown/html-css/README.md
+++ b/trainingbreakdown/html-css/README.md
@@ -28,7 +28,7 @@
 * Developer Tools
 * Adding a Video to your site
 * Styling to change fonts and location of elements
-* Hosting on Github Pages
+* Hosting on Netlify
 
 ## Course Outcome
 

--- a/trainingbreakdown/html-css/lesson-plan/README.md
+++ b/trainingbreakdown/html-css/lesson-plan/README.md
@@ -199,7 +199,7 @@ Students cover more advanced CSS concepts and continue with their portfolio
 
 Students will be completing work on their portfolio
 
-* Deploy portfolio on GitHub pages
+* Deploy portfolio on Netlify
 
 ### Session 6 classroom tasks
 


### PR DESCRIPTION
Unless a custom domain name is used, when using GitHub pages the name of the org/repo is used in the domain name. 
Because of our integration with GitHub Classroom each student's domain name would be something like `blackcodherbootcamp.github.io/unit02assessment{studentName}` which is not ideal. 

If we use Netlify instead they can edit the site name to be whatever they like - `{student}.netlify.app`