### PR TITLE
fix: correcting broken lesson plan links

### DIFF
--- a/trainingbreakdown/databases/README.md
+++ b/trainingbreakdown/databases/README.md
@@ -3,7 +3,7 @@
 1. [Unit Outline](#unit-outline)
 1. [Unit Outcome](#unit-outcome)
 <!-- 1. [Related Empowerment Day](#related-empowerment-day) -->
-1. [Unit Lesson Plans](#unit-lesson-plans)
+<!-- 1. [Unit Lesson Plans](#unit-lesson-plans) -->
 
 ## Unit Outline
 
@@ -49,6 +49,6 @@
 - React app updated and pushed to GitHub
 - Understanding of different types of database structures
 
-## Unit Lesson Plans
+<!-- ## Unit Lesson Plans
 
-For details of what is cover each session of in each lesson plan take a look [here](lesson-plan)
+For details of what is cover each session of in each lesson plan take a look [here](lesson-plan) -->

--- a/trainingbreakdown/databases/README.md
+++ b/trainingbreakdown/databases/README.md
@@ -51,4 +51,4 @@
 
 ## Unit Lesson Plans
 
-For details of what is cover each session of in each lesson plan take a look [here](lessonplan)
+For details of what is cover each session of in each lesson plan take a look [here](lesson-plan)

--- a/trainingbreakdown/html-css/README.md
+++ b/trainingbreakdown/html-css/README.md
@@ -45,4 +45,4 @@
 
 ## Unit Lesson Plans
 
-For details of what is cover each session of in each lesson plan take a look [here](lessonplan)
+For details of what is cover each session of in each lesson plan take a look [here](lesson-plan)

--- a/trainingbreakdown/intro-to-development/README.md
+++ b/trainingbreakdown/intro-to-development/README.md
@@ -91,4 +91,4 @@ Students will be given a thorough introduction to the command line/terminal and 
 
 ## Unit Lesson Plans
 
-For details of what is cover each session of in each lesson plan take a look [here](lessonplan)
+For details of what is cover each session of in each lesson plan take a look [here](lesson-plan)

--- a/trainingbreakdown/javascript/README.md
+++ b/trainingbreakdown/javascript/README.md
@@ -41,4 +41,4 @@
 
 ## Unit Lesson Plans
 
-For details of what is cover each session of in each lesson plan take a look [here](lessonplan)
+For details of what is cover each session of in each lesson plan take a look [here](lesson-plan)

--- a/trainingbreakdown/react/README.md
+++ b/trainingbreakdown/react/README.md
@@ -38,4 +38,4 @@ The learner will have a solid understanding of ReactJs and how to build a single
 
 ## Unit Lesson Plans
 
-For details of what is cover each session of in each lesson plan take a look [here](lessonplan)
+For details of what is cover each session of in each lesson plan take a look [here](lesson-plan)


### PR DESCRIPTION
Missed the `-` in `lesson-plan` so links weren't working